### PR TITLE
Add config manager to fetch secrets and environment specific urls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ screenshots/
 
 # node_modules
 node_modules/
+
+# local_secrets.yaml
+local_secrets.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,8 @@
         "--output=./test-failures",
         "--screenshot=only-on-failure",
         "--video=retain-on-failure",
+        "--env=development",
+        "--yaml-config=local_secrets.yaml",
         "-svv"
     ],
     "makefile.configureOnOpen": false

--- a/automate_ui/common/__init__.py
+++ b/automate_ui/common/__init__.py
@@ -1,0 +1,1 @@
+# Common utilities for the automate_ui package

--- a/automate_ui/common/utils/__init__.py
+++ b/automate_ui/common/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility functions for the automate_ui package

--- a/automate_ui/common/utils/aws_secrets.py
+++ b/automate_ui/common/utils/aws_secrets.py
@@ -1,0 +1,151 @@
+import json
+from typing import Any, Dict, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import NoRegionError
+
+from .config_loader import get_nested_value
+from .config_loader import load_yaml_config
+
+
+def check_aws_credentials() -> bool:
+    """
+    Check if AWS credentials are available and valid.
+
+    Returns:
+        True if AWS credentials are available and can be used, False otherwise
+    """
+    try:
+        # Try to create a session to check credentials
+        session = boto3.Session()
+        sts = session.client('sts')
+        sts.get_caller_identity()
+        return True
+    except (NoCredentialsError, NoRegionError, ClientError):
+        return False
+
+
+def get_secret_from_aws(secret_name: str, region_name: str = None) -> Optional[Dict[str, Any]]:
+    """
+    Retrieve a secret from AWS Secrets Manager.
+
+    Args:
+        secret_name: Name of the secret in AWS Secrets Manager
+        region_name: AWS region name (optional, uses default if not provided)
+
+    Returns:
+        Dictionary containing the secret data, or None if retrieval fails
+
+    Raises:
+        ClientError: If there's an AWS API error
+    """
+    try:
+        # Create a Secrets Manager client
+        if region_name:
+            session = boto3.session.Session()
+            client = session.client(
+                service_name='secretsmanager',
+                region_name=region_name
+            )
+        else:
+            client = boto3.client('secretsmanager')
+
+        # Get the secret
+        response = client.get_secret_value(SecretId=secret_name)
+
+        # Parse the secret string as JSON
+        if 'SecretString' in response:
+            return json.loads(response['SecretString'])
+        else:
+            # Handle binary secrets
+            return {'binary_secret': response['SecretBinary']}
+
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code == 'ResourceNotFoundException':
+            print(f"Secret '{secret_name}' not found in AWS Secrets Manager")
+        elif error_code == 'AccessDeniedException':
+            print(f"Access denied to secret '{secret_name}' in AWS Secrets Manager")
+        else:
+            print(f"AWS Secrets Manager error for '{secret_name}': {e}")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Error parsing secret '{secret_name}' as JSON: {e}")
+        return None
+    except Exception as e:
+        print(f"Unexpected error retrieving secret '{secret_name}': {e}")
+        return None
+
+
+def get_config_with_aws_fallback(
+    yaml_file_path: str,
+    aws_secret_name: str = None,
+    aws_region: str = None
+) -> Dict[str, Any]:
+    """
+    Get configuration with AWS Secrets Manager fallback.
+
+    First tries to get configuration from AWS Secrets Manager if credentials are available.
+    Falls back to YAML file if AWS is not available or fails.
+
+    Args:
+        yaml_file_path: Path to the local YAML configuration file
+        aws_secret_name: Name of the secret in AWS Secrets Manager (optional)
+        aws_region: AWS region name (optional)
+
+    Returns:
+        Dictionary containing the configuration data
+
+    Raises:
+        FileNotFoundError: If neither AWS nor YAML file is available
+    """
+    # Check if AWS credentials are available
+    if check_aws_credentials() and aws_secret_name:
+        print(f"AWS credentials available. Attempting to fetch secret '{aws_secret_name}' from AWS Secrets Manager...")
+
+        # Try to get secret from AWS
+        aws_config = get_secret_from_aws(aws_secret_name, aws_region)
+        if aws_config:
+            print(f"Successfully loaded configuration from AWS Secrets Manager: {aws_secret_name}")
+            return aws_config
+        else:
+            print(f"Failed to retrieve secret '{aws_secret_name}' from AWS. Falling back to YAML file...")
+
+    # Fallback to YAML file
+    print(f"Loading configuration from YAML file: {yaml_file_path}")
+    try:
+        return load_yaml_config(yaml_file_path)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            f"Configuration not available from AWS Secrets Manager or YAML file. "
+            f"Please ensure either AWS credentials are configured with secret '{aws_secret_name}' "
+            f"or create a local configuration file at '{yaml_file_path}'."
+        ) from e
+
+
+def get_nested_config_value(
+    yaml_file_path: str,
+    key_path: str,
+    aws_secret_name: str = None,
+    aws_region: str = None
+) -> Any:
+    """
+    Get a nested configuration value with AWS Secrets Manager fallback.
+
+    Args:
+        yaml_file_path: Path to the local YAML configuration file
+        key_path: Dot-separated path to the value (e.g., 'api.public.key')
+        aws_secret_name: Name of the secret in AWS Secrets Manager (optional)
+        aws_region: AWS region name (optional)
+
+    Returns:
+        The value at the specified path
+
+    Raises:
+        KeyError: If the key path doesn't exist in the configuration
+        FileNotFoundError: If neither AWS nor YAML file is available
+    """
+    config = get_config_with_aws_fallback(yaml_file_path, aws_secret_name, aws_region)
+    return get_nested_value(config, key_path)

--- a/automate_ui/common/utils/config_loader.py
+++ b/automate_ui/common/utils/config_loader.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+def load_yaml_config(file_path: str) -> Dict[str, Any]:
+    """
+    Load configuration from a YAML file.
+
+    Args:
+        file_path: Path to the YAML configuration file
+
+    Returns:
+        Dictionary containing the configuration data
+
+    Raises:
+        FileNotFoundError: If the YAML file doesn't exist
+        yaml.YAMLError: If the YAML file is malformed
+    """
+    try:
+        with open(file_path, 'r') as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"Configuration file not found: {file_path}. "
+            f"Please ensure the file exists and is accessible. "
+            f"For local development, create a '{file_path}' file with your configuration."
+        )
+    except yaml.YAMLError as e:
+        raise yaml.YAMLError(f"Error parsing YAML file {file_path}: {e}")
+    except PermissionError:
+        raise PermissionError(f"Permission denied accessing configuration file: {file_path}")
+    except Exception as e:
+        raise Exception(f"Unexpected error loading configuration file {file_path}: {e}")
+
+
+def get_nested_value(config: Dict[str, Any], key_path: str) -> Any:
+    """
+    Get a nested value from a configuration dictionary using dot notation.
+
+    Args:
+        config: Configuration dictionary
+        key_path: Dot-separated path to the value (e.g., 'api.public.key')
+
+    Returns:
+        The value at the specified path
+
+    Raises:
+        KeyError: If the key path doesn't exist in the configuration
+    """
+    keys = key_path.split('.')
+    current = config
+
+    for key in keys:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            raise KeyError(f"Key path '{key_path}' not found in configuration")
+
+    return current
+
+
+def get_nested_value_safe(config: Dict[str, Any], key_path: str) -> Any:
+    """
+    Get a nested value from a configuration dictionary using dot notation with appropriate error handling.
+
+    Args:
+        config: Configuration dictionary
+        key_path: Dot-separated path to the value (e.g., 'api.public.key')
+
+    Returns:
+        The value at the specified path
+
+    Raises:
+        KeyError: If the key path doesn't exist in the configuration with a descriptive message
+    """
+    try:
+        return get_nested_value(config, key_path)
+    except KeyError:
+        raise KeyError(f"Configuration key '{key_path}' not found. Please check your configuration file.")

--- a/automate_ui/common/utils/config_manager.py
+++ b/automate_ui/common/utils/config_manager.py
@@ -1,0 +1,153 @@
+"""
+Configuration manager that combines AWS secrets with environment-specific URLs.
+This module provides a unified interface for accessing both secrets and environment-specific configurations.
+"""
+
+from typing import Any, Dict, Optional
+
+from .aws_secrets import get_config_with_aws_fallback
+from .aws_secrets import get_nested_value
+from .environment_urls import get_environment_database_config
+from .environment_urls import get_environment_url
+from .environment_urls import get_environment_urls
+
+
+class ConfigManager:
+    """
+    Manages configuration by combining AWS secrets with environment-specific URLs.
+    """
+
+    def __init__(self, yaml_file_path: str, environment: str, aws_secret_name: Optional[str] = None, aws_region: Optional[str] = None):
+        """
+        Initialize the config manager.
+
+        Args:
+            yaml_file_path: Path to the YAML configuration file
+            environment: Environment name (development/staging/production)
+            aws_secret_name: AWS Secrets Manager secret name (optional)
+            aws_region: AWS region (optional)
+        """
+        self.yaml_file_path = yaml_file_path
+        self.environment = environment
+        self.aws_secret_name = aws_secret_name
+        self.aws_region = aws_region
+
+        # Load secrets from AWS or YAML
+        self.secrets = get_config_with_aws_fallback(
+            yaml_file_path=yaml_file_path,
+            aws_secret_name=aws_secret_name,
+            aws_region=aws_region
+        )
+
+        # Load environment-specific URLs
+        self.env_urls = get_environment_urls(environment)
+
+    def get_secret(self, key_path: str) -> Any:
+        """
+        Get a secret value using dot notation.
+
+        Args:
+            key_path: Dot-separated path to the secret (e.g., 'api.public.key')
+
+        Returns:
+            The secret value
+
+        Raises:
+            KeyError: If the key path doesn't exist
+        """
+        return get_nested_value(self.secrets, key_path)
+
+    def get_url(self, service: str, url_type: str = "base_url") -> str:
+        """
+        Get an environment-specific URL.
+
+        Args:
+            service: The service name (api.public, web_app, mobile_app, etc.)
+            url_type: The URL type (base_url, admin_url, internal_url, etc.)
+
+        Returns:
+            The URL for the specified service and type
+
+        Raises:
+            KeyError: If the service or URL type doesn't exist
+        """
+        return get_environment_url(self.environment, service, url_type)
+
+    def get_database_config(self) -> Dict[str, Any]:
+        """
+        Get database configuration for the current environment.
+
+        Returns:
+            Dictionary containing database configuration
+        """
+        return get_environment_database_config(self.environment)
+
+    def get_api_config(self) -> Dict[str, Any]:
+        """
+        Get complete API configuration (secrets + URLs) for the current environment.
+
+        Returns:
+            Dictionary containing API configuration
+        """
+        return {
+            "public": {
+                "key": self.get_secret("api.public.key"),
+                "base_url": self.get_url("api.public", "base_url")
+            },
+            "private": {
+                "admin_key": self.get_secret("api.private.admin_key"),
+                "internal_url": self.get_url("api.private", "internal_url")
+            }
+        }
+
+    def get_web_app_config(self) -> Dict[str, str]:
+        """
+        Get web app configuration for the current environment.
+
+        Returns:
+            Dictionary containing web app URLs
+        """
+        return {
+            "base_url": self.get_url("web_app", "base_url"),
+            "admin_url": self.get_url("web_app", "admin_url")
+        }
+
+
+
+    def get_aws_config(self) -> Dict[str, Any]:
+        """
+        Get AWS configuration (from secrets).
+
+        Returns:
+            Dictionary containing AWS configuration
+        """
+        return {
+            "region": self.get_secret("aws.region"),
+            "access_key": self.get_secret("aws.access_key"),
+            "secret_key": self.get_secret("aws.secret_key")
+        }
+
+    def get_all_secrets(self) -> Dict[str, Any]:
+        """
+        Get all secrets (from YAML/AWS).
+
+        Returns:
+            Dictionary containing all secrets
+        """
+        return self.secrets
+
+
+def create_config_manager(yaml_file_path: str, environment: str, aws_secret_name: Optional[str] = None, aws_region: Optional[str] = None) -> ConfigManager:
+    """
+    Create a config manager instance.
+
+    Args:
+        yaml_file_path: Path to the YAML configuration file
+        environment: Environment name (development/staging/production)
+        aws_secret_name: AWS Secrets Manager secret name (optional)
+        aws_region: AWS region (optional)
+
+    Returns:
+        ConfigManager instance
+    """
+    return ConfigManager(yaml_file_path, environment, aws_secret_name, aws_region)

--- a/automate_ui/common/utils/environment_urls.py
+++ b/automate_ui/common/utils/environment_urls.py
@@ -1,0 +1,153 @@
+"""
+Environment-specific URL and configuration mappings.
+This module provides environment-specific URLs that are not stored in AWS Secrets Manager.
+"""
+
+from typing import Any, Dict
+
+# Environment-specific URL mappings
+ENVIRONMENT_URLS = {
+    "development": {
+        "api": {
+            "public": {
+                "base_url": "https://dev-api.example.com"
+            },
+            "private": {
+                "internal_url": "https://dev-internal-api.example.com"
+            }
+        },
+        "web_app": {
+            "base_url": "https://www.google.com",
+            "admin_url": "https://dev-admin.example.com"
+        },
+
+        "database": {
+            "host": "dev-db.example.com",
+            "port": 5432,
+            "username": "dev_user",
+            "password": "dev_password",
+            "name": "dev_database"
+        }
+    },
+    "staging": {
+        "api": {
+            "public": {
+                "base_url": "https://staging-api.example.com"
+            },
+            "private": {
+                "internal_url": "https://staging-internal-api.example.com"
+            }
+        },
+        "web_app": {
+            "base_url": "https://staging-app.example.com",
+            "admin_url": "https://staging-admin.example.com"
+        },
+
+        "database": {
+            "host": "staging-db.example.com",
+            "port": 5432,
+            "username": "staging_user",
+            "password": "staging_password",
+            "name": "staging_database"
+        }
+    },
+    "production": {
+        "api": {
+            "public": {
+                "base_url": "https://api.example.com"
+            },
+            "private": {
+                "internal_url": "https://internal-api.example.com"
+            }
+        },
+        "web_app": {
+            "base_url": "https://app.example.com",
+            "admin_url": "https://admin.example.com"
+        },
+
+        "database": {
+            "host": "prod-db.example.com",
+            "port": 5432,
+            "username": "prod_user",
+            "password": "prod_password",
+            "name": "prod_database"
+        }
+    }
+}
+
+
+def get_environment_urls(environment: str) -> Dict[str, Any]:
+    """
+    Get environment-specific URLs and configurations.
+
+    Args:
+        environment: The environment name (development/staging/production)
+
+    Returns:
+        Dictionary containing environment-specific URLs and configurations
+
+    Raises:
+        KeyError: If the environment doesn't exist
+    """
+    if environment not in ENVIRONMENT_URLS:
+        available_envs = list(ENVIRONMENT_URLS.keys())
+        raise KeyError(f"Environment '{environment}' not found. Available environments: {available_envs}")
+
+    return ENVIRONMENT_URLS[environment]
+
+
+def get_environment_url(environment: str, service: str, url_type: str = "base_url") -> str:
+    """
+    Get a specific URL for an environment and service.
+
+    Args:
+        environment: The environment name (development/staging/production)
+        service: The service name (api.public, web_app, mobile_app, etc.)
+        url_type: The URL type (base_url, admin_url, internal_url, etc.)
+
+    Returns:
+        The URL for the specified environment, service, and type
+
+    Raises:
+        KeyError: If the environment, service, or URL type doesn't exist
+    """
+    env_urls = get_environment_urls(environment)
+
+    # Navigate to the service level
+    service_parts = service.split('.')
+    current = env_urls
+
+    for part in service_parts:
+        if part not in current:
+            raise KeyError(f"Service '{service}' not found in environment '{environment}'")
+        current = current[part]
+
+    # Get the specific URL type
+    if url_type not in current:
+        raise KeyError(f"URL type '{url_type}' not found for service '{service}' in environment '{environment}'")
+
+    return current[url_type]
+
+
+def get_available_environments() -> list:
+    """
+    Get list of available environments.
+
+    Returns:
+        List of available environment names
+    """
+    return list(ENVIRONMENT_URLS.keys())
+
+
+def get_environment_database_config(environment: str) -> Dict[str, Any]:
+    """
+    Get database configuration for a specific environment.
+
+    Args:
+        environment: The environment name (development/staging/production)
+
+    Returns:
+        Dictionary containing database configuration
+    """
+    env_urls = get_environment_urls(environment)
+    return env_urls.get("database", {})

--- a/automate_ui/screenplay/core/models/base/faker_providers.py
+++ b/automate_ui/screenplay/core/models/base/faker_providers.py
@@ -1,6 +1,7 @@
+from typing import Dict
+
 from faker.providers import BaseProvider
 import pycountry
-from typing import Dict
 
 
 class CountrySpecificProvider(BaseProvider):
@@ -132,24 +133,24 @@ class PhoneNumberGenerator:
                 "228", "229", "231", "234", "239", "240", "248", "251", "252", "253"
             ]
             area_code = faker.random_element(valid_area_codes)
-            prefix = faker.random_number(digits=3)
-            line = faker.random_number(digits=4)
+            prefix = faker.random_number(digits=3, fix_len=True)
+            line = faker.random_number(digits=4, fix_len=True)
 
             return f"{country_code}{area_code}{prefix}{line}"
         elif country == "Australia":
             # Australian format: +61XXXXXXXXX
             mobile_prefix = "4"  # Australian mobile numbers start with 4
-            remaining_digits = faker.random_number(digits=8)
+            remaining_digits = faker.random_number(digits=8, fix_len=True)
             return f"{country_code}{mobile_prefix}{remaining_digits}"
         elif country == "United Kingdom":
             # UK format: +44XXXXXXXXXX
             mobile_prefix = "7"  # UK mobile numbers start with 7
-            remaining_digits = faker.random_number(digits=9)
+            remaining_digits = faker.random_number(digits=9, fix_len=True)
             return f"{country_code}{mobile_prefix}{remaining_digits}"
         elif country == "Singapore":
             # Singapore format: +65XXXXXXXX
             mobile_prefix = "8"  # Singapore mobile numbers start with 8 or 9
-            remaining_digits = faker.random_number(digits=7)
+            remaining_digits = faker.random_number(digits=7, fix_len=True)
             return f"{country_code}{mobile_prefix}{remaining_digits}"
         else:
-            return f"{country_code}{faker.random_number(digits=10)}"
+            return f"{country_code}{faker.random_number(digits=10, fix_len=True)}"

--- a/automate_ui/screenplay/core/models/user/generate_user.py
+++ b/automate_ui/screenplay/core/models/user/generate_user.py
@@ -1,14 +1,21 @@
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from random import random
+import string
 from typing import List, Optional
-from datetime import datetime, timedelta, date
+
 from faker import Faker
 
-
+from ..base.faker_providers import CountrySpecificProvider
+from ..base.faker_providers import PhoneNumberGenerator
 from ..base.name import BaseName
 from ..base.phone import BasePhone
-from ..base.faker_providers import CountrySpecificProvider, PhoneNumberGenerator
 from .address import UserAddress
-from .personal_information import PersonalInformation, BirthLocation
+from .personal_information import BirthLocation
+from .personal_information import PersonalInformation
 from .user import User
+
 
 class GenerateUserPersona:
     """Builder for creating user personas with a fluent interface."""
@@ -123,7 +130,7 @@ class GenerateUserPersona:
             self._email_address = email
         else:
             # Generate random 6 character string
-            random_str = self.faker.random_letters(6)
+            random_str = ''.join(self.faker.random_choices(elements=string.ascii_lowercase, length=6))
             # Get first and last name from personal info if available
             if self._personal_info:
                 given_name = self._personal_info.name.given_name.lower()

--- a/aws_secret_example.json
+++ b/aws_secret_example.json
@@ -1,0 +1,26 @@
+{
+  "api": {
+    "public": {
+      "key": "aws-api-key-here",
+      "base_url": "https://api.example.com"
+    },
+    "private": {
+      "admin_key": "admin-api-key-for-aws",
+      "internal_url": "https://internal-api.example.com"
+    }
+  },
+  "database": {
+    "development": {
+      "host": "aws-db-host",
+      "port": 5432,
+      "username": "aws_user",
+      "password": "aws_password",
+      "name": "aws_database"
+    }
+  },
+  "aws": {
+    "region": "us-east-1",
+    "access_key": "aws-access-key",
+    "secret_key": "aws-secret-key"
+  }
+}

--- a/example_aws_integration.py
+++ b/example_aws_integration.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Example script demonstrating AWS Secrets Manager integration with YAML fallback.
+"""
+
+from automate_ui.common.utils.config_manager import ConfigManager
+
+
+def example_usage():
+    """Demonstrate how to use the AWS integration with fallback."""
+
+    print("=== AWS Secrets Manager Integration Example ===\n")
+
+    # Example 1: Try AWS first, fallback to YAML
+    try:
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development',
+            aws_secret_name='my-app-secrets',
+            aws_region='us-east-1'
+        )
+        api_key = config_manager.get_secret('api.public.key')
+        print(f"Retrieved API key: {api_key}")
+    except Exception as e:
+        print(f"Error retrieving API key: {e}")
+
+    # Example 2: Database configuration
+    try:
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development',
+            aws_secret_name='my-app-database-secrets'
+        )
+        db_config = config_manager.get_database_config()
+        print(f"Database host: {db_config['host']}")
+    except Exception as e:
+        print(f"Error retrieving database host: {e}")
+
+    # Example 3: AWS credentials (for AWS services)
+    try:
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development',
+            aws_secret_name='my-app-aws-config'
+        )
+        aws_region = config_manager.get_secret('aws.region')
+        print(f"AWS region: {aws_region}")
+    except Exception as e:
+        print(f"Error retrieving AWS region: {e}")
+
+    # Example 4: Environment-specific URLs
+    try:
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='production',
+            aws_secret_name='my-app-prod-secrets'
+        )
+        api_url = config_manager.get_url('api.public', 'base_url')
+        web_url = config_manager.get_url('web_app', 'base_url')
+        print(f"Production API URL: {api_url}")
+        print(f"Production Web URL: {web_url}")
+    except Exception as e:
+        print(f"Error retrieving URLs: {e}")
+
+if __name__ == "__main__":
+    example_usage()

--- a/example_environment_usage.py
+++ b/example_environment_usage.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating environment-specific configuration usage.
+"""
+
+from automate_ui.apps.api_app.client import APIClient
+
+
+def example_development_usage():
+    """Example usage for development environment."""
+    print("=== Development Environment Example ===\n")
+
+    # This would be run with: pytest --env=development
+    # Or use the default development environment
+
+    # In a real test, you would inject the config fixture:
+    # def test_development_api(config_manager):
+    #     api_key = config_manager.get_secret('api.public.key')
+    #     api_url = config_manager.get_url('api.public', 'base_url')
+
+    # For demonstration, we'll simulate the config values
+    api_key = "dev-api-key-here"
+    api_url = "https://dev-api.example.com"
+    web_url = "https://dev-app.example.com"
+
+    print(f"API Key: {api_key}")
+    print(f"API URL: {api_url}")
+    print(f"Web App URL: {web_url}")
+
+    # Create API client
+    client = APIClient(base_url=api_url)
+    client.authenticate(api_key=api_key)
+
+    print(f"Configured API Client: {client.base_url}")
+    print(f"Authorization Header: {client.session.headers.get('Authorization')}")
+
+
+def example_staging_usage():
+    """Example usage for staging environment."""
+    print("\n=== Staging Environment Example ===\n")
+
+    # This would be run with: pytest --env=staging
+
+    # Simulate staging config values
+    api_key = "staging-api-key-here"
+    api_url = "https://staging-api.example.com"
+    web_url = "https://staging-app.example.com"
+
+    print(f"API Key: {api_key}")
+    print(f"API URL: {api_url}")
+    print(f"Web App URL: {web_url}")
+
+    # Create API client
+    client = APIClient(base_url=api_url)
+    client.authenticate(api_key=api_key)
+
+    print(f"Configured API Client: {client.base_url}")
+    print(f"Authorization Header: {client.session.headers.get('Authorization')}")
+
+
+def example_production_usage():
+    """Example usage for production environment."""
+    print("\n=== Production Environment Example ===\n")
+
+    # This would be run with: pytest --env=production
+
+    # Simulate production config values
+    api_key = "prod-api-key-here"
+    api_url = "https://api.example.com"
+    web_url = "https://app.example.com"
+
+    print(f"API Key: {api_key}")
+    print(f"API URL: {api_url}")
+    print(f"Web App URL: {web_url}")
+
+    # Create API client
+    client = APIClient(base_url=api_url)
+    client.authenticate(api_key=api_key)
+
+    print(f"Configured API Client: {client.base_url}")
+    print(f"Authorization Header: {client.session.headers.get('Authorization')}")
+
+
+def example_command_line_options():
+    """Example of different command-line options."""
+    print("\n=== Command Line Options Examples ===\n")
+
+    print("1. Default development environment:")
+    print("   pytest")
+    print("   # Uses: local_secrets.yaml, env=development")
+
+    print("\n2. Staging environment with custom YAML:")
+    print("   pytest --env=staging --yaml-config=staging_secrets.yaml")
+
+    print("\n3. Production environment with AWS Secrets Manager:")
+    print("   pytest --env=production --aws-secret=my-app-prod-secrets --aws-region=us-west-2")
+
+    print("\n4. Custom environment with all options:")
+    print("   pytest --env=staging --yaml-config=custom.yaml --aws-secret=backup-secrets --aws-region=eu-west-1")
+
+
+def example_test_scenarios():
+    """Example test scenarios using the environment config."""
+    print("\n=== Example Test Scenarios ===\n")
+
+    print("1. API Integration Test:")
+    print("""
+    def test_api_integration(config_manager):
+        # Get environment-specific API configuration
+        api_key = config_manager.get_secret('api.public.key')
+        api_url = config_manager.get_url('api.public', 'base_url')
+
+        # Create API client
+        client = APIClient(base_url=api_url)
+        client.authenticate(api_key=api_key)
+
+        # Make API calls
+        response = client.get('/users')
+        assert response.status_code == 200
+    """)
+
+    print("\n2. Web App Test:")
+    print("""
+    def test_web_app_login(config_manager):
+        # Get environment-specific web app URL
+        web_url = config_manager.get_url('web_app', 'base_url')
+
+        # Navigate to web app
+        page.goto(web_url)
+
+        # Perform login test
+        page.fill('#username', 'test@example.com')
+        page.fill('#password', 'password')
+        page.click('#login-button')
+
+        assert page.url.endswith('/dashboard')
+    """)
+
+    print("\n3. Admin Panel Test:")
+    print("""
+    def test_admin_panel(config_manager):
+        # Get environment-specific admin panel URL
+        admin_url = config_manager.get_url('web_app', 'admin_url')
+
+        # Navigate to admin panel
+        page.goto(admin_url)
+
+        # Perform admin authentication
+        page.fill('#admin-username', 'admin@example.com')
+        page.fill('#admin-password', 'admin-password')
+        page.click('#admin-login')
+
+        assert page.url.endswith('/admin/dashboard')
+    """)
+
+    print("\n4. Database Test:")
+    print("""
+    def test_database_connection(config_manager):
+        # Get environment-specific database config
+        db_config = config_manager.get_database_config()
+        db_host = db_config['host']
+        db_port = db_config['port']
+        db_name = db_config['name']
+
+        # Test database connection
+        # ... database testing code ...
+    """)
+
+
+if __name__ == "__main__":
+    example_development_usage()
+    example_staging_usage()
+    example_production_usage()
+    example_command_line_options()
+    example_test_scenarios()

--- a/example_new_architecture.py
+++ b/example_new_architecture.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the new architecture with separated secrets and environment URLs.
+"""
+
+from automate_ui.apps.api_app.client import APIClient
+from automate_ui.common.utils.config_manager import ConfigManager
+from automate_ui.common.utils.config_manager import create_config_manager
+
+
+def example_direct_config_manager_usage():
+    """Example of using ConfigManager directly."""
+    print("=== Direct ConfigManager Usage ===\n")
+
+    # Create config manager for development environment
+    config_manager = ConfigManager(
+        yaml_file_path='local_secrets.yaml',
+        environment='development'
+    )
+
+    # Get secrets (from YAML/AWS)
+    api_key = config_manager.get_secret('api.public.key')
+    admin_key = config_manager.get_secret('api.private.admin_key')
+
+    # Get environment-specific URLs
+    api_url = config_manager.get_url('api.public', 'base_url')
+    web_url = config_manager.get_url('web_app', 'base_url')
+    admin_url = config_manager.get_url('web_app', 'admin_url')
+
+    print(f"API Key: {api_key}")
+    print(f"API URL: {api_url}")
+    print(f"Web App URL: {web_url}")
+    print(f"Admin URL: {admin_url}")
+
+    # Create API client
+    client = APIClient(base_url=api_url)
+    client.authenticate(api_key=api_key)
+
+    print(f"Configured API Client: {client.base_url}")
+
+
+def example_different_environments():
+    """Example of using different environments."""
+    print("\n=== Different Environments ===\n")
+
+    environments = ['development', 'staging', 'production']
+
+    for env in environments:
+        print(f"--- {env.upper()} Environment ---")
+
+        config_manager = ConfigManager('local_secrets.yaml', env)
+
+                # Same secrets, different URLs
+        api_key = config_manager.get_secret('api.public.key')  # Same key
+        api_url = config_manager.get_url('api.public', 'base_url')  # Different URL
+        web_url = config_manager.get_url('web_app', 'base_url')  # Different URL
+        admin_url = config_manager.get_url('web_app', 'admin_url')  # Different URL
+
+        print(f"API Key: {api_key}")
+        print(f"API URL: {api_url}")
+        print(f"Web URL: {web_url}")
+        print(f"Admin URL: {admin_url}")
+        print()
+
+
+def example_aws_integration():
+    """Example of AWS integration with environment URLs."""
+    print("\n=== AWS Integration Example ===\n")
+
+    # This would be used when AWS credentials are available
+    config_manager = ConfigManager(
+        yaml_file_path='local_secrets.yaml',
+        environment='production',
+        aws_secret_name='my-app-prod-secrets',
+        aws_region='us-west-2'
+    )
+
+    # Secrets come from AWS, URLs come from environment mapping
+    api_key = config_manager.get_secret('api.public.key')  # From AWS
+    api_url = config_manager.get_url('api.public', 'base_url')  # From environment mapping
+
+    print(f"API Key: {api_key}")
+    print(f"API URL: {api_url}")
+
+
+def example_complete_configurations():
+    """Example of getting complete configurations."""
+    print("\n=== Complete Configurations ===\n")
+
+    config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+    # Get complete API configuration
+    api_config = config_manager.get_api_config()
+    print("API Configuration:")
+    print(f"  Public Key: {api_config['public']['key']}")
+    print(f"  Public URL: {api_config['public']['base_url']}")
+    print(f"  Admin Key: {api_config['private']['admin_key']}")
+    print(f"  Internal URL: {api_config['private']['internal_url']}")
+
+    # Get complete web app configuration
+    web_config = config_manager.get_web_app_config()
+    print("\nWeb App Configuration:")
+    print(f"  Base URL: {web_config['base_url']}")
+    print(f"  Admin URL: {web_config['admin_url']}")
+
+    # Get database configuration
+    db_config = config_manager.get_database_config()
+    print("\nDatabase Configuration:")
+    print(f"  Host: {db_config['host']}")
+    print(f"  Port: {db_config['port']}")
+    print(f"  Username: {db_config['username']}")
+    print(f"  Database: {db_config['name']}")
+
+
+def example_test_scenarios():
+    """Example test scenarios using the new architecture."""
+    print("\n=== Test Scenarios ===\n")
+
+    print("1. API Integration Test:")
+    print("""
+    def test_api_integration(config_manager):
+        # Get API configuration
+        api_key = config_manager.get_secret('api.public.key')
+        api_url = config_manager.get_url('api.public', 'base_url')
+
+        # Create API client
+        client = APIClient(base_url=api_url)
+        client.authenticate(api_key=api_key)
+
+        # Make API calls
+        response = client.get('/users')
+        assert response.status_code == 200
+    """)
+
+    print("\n2. Web App Test:")
+    print("""
+    def test_web_app_login(config_manager):
+        # Get web app URL
+        web_url = config_manager.get_url('web_app', 'base_url')
+
+        # Navigate to web app
+        page.goto(web_url)
+
+        # Perform login test
+        page.fill('#username', 'test@example.com')
+        page.fill('#password', 'password')
+        page.click('#login-button')
+
+        assert page.url.endswith('/dashboard')
+    """)
+
+    print("\n3. Database Test:")
+    print("""
+    def test_database_connection(config_manager):
+        # Get database configuration
+        db_config = config_manager.get_database_config()
+
+        # Test database connection
+        connection = create_db_connection(
+            host=db_config['host'],
+            port=db_config['port'],
+            username=db_config['username'],
+            password=db_config['password'],
+            database=db_config['name']
+        )
+
+        assert connection.is_connected()
+    """)
+
+
+def example_command_line_usage():
+    """Example of command-line usage."""
+    print("\n=== Command Line Usage ===\n")
+
+    print("1. Development environment (default):")
+    print("   pytest")
+    print("   # Uses: local_secrets.yaml, env=development")
+
+    print("\n2. Staging environment:")
+    print("   pytest --env=staging")
+    print("   # Uses: local_secrets.yaml, env=staging")
+
+    print("\n3. Production with AWS:")
+    print("   pytest --env=production --aws-secret=my-app-prod-secrets --aws-region=us-west-2")
+    print("   # Uses: AWS secrets, env=production URLs")
+
+    print("\n4. Custom YAML with staging:")
+    print("   pytest --env=staging --yaml-config=staging_secrets.yaml")
+    print("   # Uses: staging_secrets.yaml, env=staging URLs")
+
+
+if __name__ == "__main__":
+    example_direct_config_manager_usage()
+    example_different_environments()
+    example_aws_integration()
+    example_complete_configurations()
+    example_test_scenarios()
+    example_command_line_usage()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,69 @@ from automate_ui.screenplay.core.models.user.generate_user import GenerateUserPe
 from automate_ui.screenplay.core.models.user.user import User
 from automate_ui.screenplay.core.ui.tasks.screenshot_page import ScreenshotPage
 # from playwright._impl._api_structures import ViewportSize
+from automate_ui.common.utils.config_manager import create_config_manager
+
+
+def pytest_addoption(parser):
+    """Add command-line options for configuration override."""
+    parser.addoption(
+        "--yaml-config",
+        action="store",
+        default="local_secrets.yaml",
+        help="Path to YAML configuration file (default: local_secrets.yaml)"
+    )
+    parser.addoption(
+        "--aws-secret",
+        action="store",
+        default=None,
+        help="AWS Secrets Manager secret name to use instead of YAML"
+    )
+    parser.addoption(
+        "--aws-region",
+        action="store",
+        default=None,
+        help="AWS region for Secrets Manager (default: uses AWS default)"
+    )
+    parser.addoption(
+        "--env",
+        action="store",
+        default="development",
+        choices=["development", "staging", "production"],
+        help="Environment to use for configuration (default: development)"
+    )
+
+
+@pytest.fixture(scope='session')
+def config_manager(request):
+    """
+    Pytest fixture to provide a config manager that combines secrets with environment URLs.
+
+    Usage:
+        def test_something(config_manager):
+            api_key = config_manager.get_secret('api.public.key')
+            api_url = config_manager.get_url('api.public', 'base_url')
+            web_url = config_manager.get_url('web_app', 'base_url')
+
+    Command-line options:
+        --yaml-config: Path to YAML file (default: local_secrets.yaml)
+        --aws-secret: AWS Secrets Manager secret name
+        --aws-region: AWS region for Secrets Manager
+        --env: Environment to use (development/staging/production, default: development)
+    """
+    yaml_file_path = request.config.getoption("--yaml-config")
+    aws_secret_name = request.config.getoption("--aws-secret")
+    aws_region = request.config.getoption("--aws-region")
+    environment = request.config.getoption("--env")
+
+    return create_config_manager(
+        yaml_file_path=yaml_file_path,
+        environment=environment,
+        aws_secret_name=aws_secret_name,
+        aws_region=aws_region
+    )
+
+
+
 
 
 @pytest.fixture(scope='class')

--- a/tests/unit/test_actor_factory.py
+++ b/tests/unit/test_actor_factory.py
@@ -1,6 +1,4 @@
-import time
-
-from automate_ui.screenplay.abilities.browse_the_web import BrowseTheWeb
+from automate_ui.common.utils.config_manager import ConfigManager
 from automate_ui.screenplay.core.actor import Actor
 from automate_ui.screenplay.core.ui.questions.current_url import CurrentUrl
 from automate_ui.screenplay.core.ui.tasks.navigate import Navigate
@@ -8,15 +6,16 @@ from automate_ui.screenplay.core.ui.tasks.screenshot_page import ScreenshotPage
 
 
 def test_actor_factory(
-    frequent_shopper: Actor
+    frequent_shopper: Actor,
+    config_manager: ConfigManager
 ):
 
     frequent_shopper.attempts_to(
-        Navigate.to_url("https://www.google.com/"),
+        Navigate.to_url(config_manager.get_url('web_app', 'base_url')),
         ScreenshotPage("some_file.png")
     )
 
     current_url = CurrentUrl().seen_by(frequent_shopper)
     assert current_url == "https://www.google.com/"
-    # assert frequent_shopper.persona.email_address
+    assert frequent_shopper.persona.email_address
     print(frequent_shopper.persona.personal_information)

--- a/tests/unit/test_aws_secrets.py
+++ b/tests/unit/test_aws_secrets.py
@@ -1,0 +1,309 @@
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import NoRegionError
+import pytest
+
+from automate_ui.common.utils.aws_secrets import check_aws_credentials
+from automate_ui.common.utils.aws_secrets import get_config_with_aws_fallback
+from automate_ui.common.utils.aws_secrets import get_nested_config_value
+from automate_ui.common.utils.aws_secrets import get_secret_from_aws
+
+
+class TestAWSCredentials:
+    """Test cases for AWS credentials checking."""
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.Session')
+    def test_check_aws_credentials_success(self, mock_session: MagicMock):
+        """Test successful AWS credentials check."""
+        # Mock successful AWS session
+        mock_session_instance = Mock()
+        mock_sts_client = Mock()
+        mock_sts_client.get_caller_identity.return_value = {'Account': '123456789012'}
+        mock_session_instance.client.return_value = mock_sts_client
+        mock_session.return_value = mock_session_instance
+
+        assert check_aws_credentials() is True
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.Session')
+    def test_check_aws_credentials_no_credentials(self, mock_session: MagicMock):
+        """Test AWS credentials check when no credentials are available."""
+        mock_session.side_effect = NoCredentialsError()
+
+        assert check_aws_credentials() is False
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.Session')
+    def test_check_aws_credentials_no_region(self, mock_session: MagicMock):
+        """Test AWS credentials check when no region is configured."""
+        mock_session.side_effect = NoRegionError()
+
+        assert check_aws_credentials() is False
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.Session')
+    def test_check_aws_credentials_client_error(self, mock_session: MagicMock):
+        """Test AWS credentials check when client error occurs."""
+        mock_session_instance = Mock()
+        mock_sts_client = Mock()
+        mock_sts_client.get_caller_identity.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'Access Denied'}},
+            'GetCallerIdentity'
+        )
+        mock_session_instance.client.return_value = mock_sts_client
+        mock_session.return_value = mock_session_instance
+
+        assert check_aws_credentials() is False
+
+
+class TestAWSSecrets:
+    """Test cases for AWS Secrets Manager functionality."""
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.client')
+    def test_get_secret_from_aws_success(self, mock_boto_client: MagicMock):
+        """Test successful secret retrieval from AWS."""
+        # Mock AWS Secrets Manager response
+        mock_response = {
+            'SecretString': json.dumps({
+                'api': {
+                    'public': {
+                        'key': 'aws-api-key',
+                        'base_url': 'https://aws-api.example.com'
+                    }
+                }
+            })
+        }
+
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = mock_response
+        mock_boto_client.return_value = mock_client
+
+        result = get_secret_from_aws('test-secret')
+
+        assert result['api']['public']['key'] == 'aws-api-key'
+        assert result['api']['public']['base_url'] == 'https://aws-api.example.com'
+        mock_client.get_secret_value.assert_called_once_with(SecretId='test-secret')
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.session.Session')
+    def test_get_secret_from_aws_with_region(self, mock_session: MagicMock):
+        """Test secret retrieval from AWS with specific region."""
+        mock_response = {'SecretString': json.dumps({'test': 'value'})}
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = mock_response
+
+        mock_session_instance = Mock()
+        mock_session_instance.client.return_value = mock_client
+        mock_session.return_value = mock_session_instance
+
+        result = get_secret_from_aws('test-secret', 'us-east-1')
+
+        # Verify the session was created and client was called
+        mock_session.assert_called_once()
+        mock_session_instance.client.assert_called_once_with(
+            service_name='secretsmanager',
+            region_name='us-east-1'
+        )
+        assert result == {'test': 'value'}
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.client')
+    def test_get_secret_from_aws_not_found(self, mock_boto_client: MagicMock):
+        """Test secret retrieval when secret doesn't exist."""
+        mock_client = Mock()
+        mock_client.get_secret_value.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Secret not found'}},
+            'GetSecretValue'
+        )
+        mock_boto_client.return_value = mock_client
+
+        result = get_secret_from_aws('nonexistent-secret')
+
+        assert result is None
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.client')
+    def test_get_secret_from_aws_access_denied(self, mock_boto_client: MagicMock):
+        """Test secret retrieval when access is denied."""
+        mock_client = Mock()
+        mock_client.get_secret_value.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}},
+            'GetSecretValue'
+        )
+        mock_boto_client.return_value = mock_client
+
+        result = get_secret_from_aws('protected-secret')
+
+        assert result is None
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.client')
+    def test_get_secret_from_aws_invalid_json(self, mock_boto_client: MagicMock):
+        """Test secret retrieval when secret contains invalid JSON."""
+        mock_response = {'SecretString': 'invalid-json-content'}
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = mock_response
+        mock_boto_client.return_value = mock_client
+
+        result = get_secret_from_aws('invalid-json-secret')
+
+        assert result is None
+
+    @patch('automate_ui.common.utils.aws_secrets.boto3.client')
+    def test_get_secret_from_aws_binary_secret(self, mock_boto_client: MagicMock):
+        """Test secret retrieval when secret is binary."""
+        mock_response = {'SecretBinary': b'binary-secret-data'}
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = mock_response
+        mock_boto_client.return_value = mock_client
+
+        result = get_secret_from_aws('binary-secret')
+
+        assert result == {'binary_secret': b'binary-secret-data'}
+
+
+class TestConfigWithAWSFallback:
+    """Test cases for configuration with AWS fallback."""
+
+    def test_get_config_with_aws_fallback_aws_success(self):
+        """Test successful configuration retrieval from AWS."""
+        aws_config = {
+            'api': {
+                'public': {
+                    'key': 'aws-api-key',
+                    'base_url': 'https://aws-api.example.com'
+                }
+            }
+        }
+
+        with patch('automate_ui.common.utils.aws_secrets.check_aws_credentials', return_value=True), \
+             patch('automate_ui.common.utils.aws_secrets.get_secret_from_aws', return_value=aws_config):
+
+            result = get_config_with_aws_fallback('local_secrets.yaml', 'test-secret')
+
+            assert result == aws_config
+
+    def test_get_config_with_aws_fallback_yaml_fallback(self):
+        """Test fallback to YAML file when AWS fails."""
+        yaml_content = """
+        api:
+          public:
+            key: "yaml-api-key"
+            base_url: "https://yaml-api.example.com"
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            with patch('automate_ui.common.utils.aws_secrets.check_aws_credentials', return_value=True), \
+                 patch('automate_ui.common.utils.aws_secrets.get_secret_from_aws', return_value=None):
+
+                result = get_config_with_aws_fallback(temp_file, 'test-secret')
+
+                assert result['api']['public']['key'] == 'yaml-api-key'
+                assert result['api']['public']['base_url'] == 'https://yaml-api.example.com'
+        finally:
+            os.unlink(temp_file)
+
+    def test_get_config_with_aws_fallback_no_aws_credentials(self):
+        """Test fallback to YAML when AWS credentials not available."""
+        yaml_content = """
+        api:
+          public:
+            key: "yaml-api-key"
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            with patch('automate_ui.common.utils.aws_secrets.check_aws_credentials', return_value=False):
+                result = get_config_with_aws_fallback(temp_file, 'test-secret')
+
+                assert result['api']['public']['key'] == 'yaml-api-key'
+        finally:
+            os.unlink(temp_file)
+
+    def test_get_config_with_aws_fallback_no_aws_secret_name(self):
+        """Test fallback to YAML when no AWS secret name provided."""
+        yaml_content = """
+        api:
+          public:
+            key: "yaml-api-key"
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            with patch('automate_ui.common.utils.aws_secrets.check_aws_credentials', return_value=True):
+                result = get_config_with_aws_fallback(temp_file)  # No AWS secret name
+
+                assert result['api']['public']['key'] == 'yaml-api-key'
+        finally:
+            os.unlink(temp_file)
+
+    def test_get_config_with_aws_fallback_both_fail(self):
+        """Test error handling when both AWS and YAML fail."""
+        with patch('automate_ui.common.utils.aws_secrets.check_aws_credentials', return_value=True), \
+             patch('automate_ui.common.utils.aws_secrets.get_secret_from_aws', return_value=None):
+
+            with pytest.raises(FileNotFoundError) as exc_info:
+                get_config_with_aws_fallback('nonexistent.yaml', 'test-secret')
+
+            assert "Configuration not available from AWS Secrets Manager or YAML file" in str(exc_info.value)
+
+
+class TestNestedConfigValue:
+    """Test cases for nested configuration value retrieval."""
+
+    def test_get_nested_config_value_aws_success(self):
+        """Test successful nested value retrieval from AWS."""
+        aws_config = {
+            'api': {
+                'public': {
+                    'key': 'aws-api-key'
+                }
+            }
+        }
+
+        with patch('automate_ui.common.utils.aws_secrets.get_config_with_aws_fallback', return_value=aws_config):
+            result = get_nested_config_value('local_secrets.yaml', 'api.public.key', 'test-secret')
+
+            assert result == 'aws-api-key'
+
+    def test_get_nested_config_value_yaml_fallback(self):
+        """Test nested value retrieval from YAML fallback."""
+        yaml_content = """
+        api:
+          public:
+            key: "yaml-api-key"
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            with patch('automate_ui.common.utils.aws_secrets.get_config_with_aws_fallback') as mock_get_config:
+                mock_get_config.return_value = {'api': {'public': {'key': 'yaml-api-key'}}}
+
+                result = get_nested_config_value(temp_file, 'api.public.key', 'test-secret')
+
+                assert result == 'yaml-api-key'
+        finally:
+            os.unlink(temp_file)
+
+    def test_get_nested_config_value_key_not_found(self):
+        """Test error handling when nested key doesn't exist."""
+        config = {'api': {'public': {'key': 'test-key'}}}
+
+        with patch('automate_ui.common.utils.aws_secrets.get_config_with_aws_fallback', return_value=config):
+            with pytest.raises(KeyError) as exc_info:
+                get_nested_config_value('local_secrets.yaml', 'api.public.nonexistent', 'test-secret')
+
+            assert "Key path 'api.public.nonexistent' not found" in str(exc_info.value)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,189 @@
+import os
+import tempfile
+from unittest.mock import mock_open
+from unittest.mock import patch
+
+import pytest
+
+from automate_ui.common.utils.config_loader import get_nested_value
+from automate_ui.common.utils.config_loader import get_nested_value_safe
+from automate_ui.common.utils.config_loader import load_yaml_config
+
+
+class TestConfigLoader:
+    """Test cases for the config loader functionality."""
+
+    def test_load_yaml_config_success(self):
+        """Test successful loading of YAML configuration."""
+        yaml_content = """
+        api:
+          public:
+            key: "test-api-key"
+            base_url: "https://api.example.com"
+        database:
+          host: "localhost"
+          port: 5432
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            config = load_yaml_config(temp_file)
+            assert config['api']['public']['key'] == "test-api-key"
+            assert config['api']['public']['base_url'] == "https://api.example.com"
+            assert config['database']['host'] == "localhost"
+            assert config['database']['port'] == 5432
+        finally:
+            os.unlink(temp_file)
+
+    def test_load_yaml_config_file_not_found(self):
+        """Test error handling when YAML file doesn't exist."""
+        with pytest.raises(FileNotFoundError) as exc_info:
+            load_yaml_config("nonexistent_file.yaml")
+
+        assert "Configuration file not found" in str(exc_info.value)
+        assert "Please ensure the file exists" in str(exc_info.value)
+
+    def test_load_yaml_config_invalid_yaml(self):
+        """Test error handling when YAML file is malformed."""
+        invalid_yaml = """
+        api:
+          public:
+            key: "test-api-key"
+            base_url: "https://api.example.com"
+        database:
+          host: "localhost"
+          port: 5432
+        invalid: yaml: content: here
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(invalid_yaml)
+            temp_file = f.name
+
+        try:
+            with pytest.raises(Exception) as exc_info:
+                load_yaml_config(temp_file)
+            assert "Error parsing YAML file" in str(exc_info.value)
+        finally:
+            os.unlink(temp_file)
+
+    def test_load_yaml_config_permission_error(self):
+        """Test error handling when file access is denied."""
+        with patch('builtins.open', side_effect=PermissionError("Permission denied")):
+            with pytest.raises(PermissionError) as exc_info:
+                load_yaml_config("test.yaml")
+            assert "Permission denied accessing configuration file" in str(exc_info.value)
+
+    def test_get_nested_value_success(self):
+        """Test successful retrieval of nested values."""
+        config = {
+            'api': {
+                'public': {
+                    'key': 'test-api-key',
+                    'base_url': 'https://api.example.com'
+                },
+                'private': {
+                    'admin_key': 'admin-key'
+                }
+            },
+            'database': {
+                'host': 'localhost',
+                'port': 5432
+            }
+        }
+
+        assert get_nested_value(config, 'api.public.key') == 'test-api-key'
+        assert get_nested_value(config, 'api.public.base_url') == 'https://api.example.com'
+        assert get_nested_value(config, 'api.private.admin_key') == 'admin-key'
+        assert get_nested_value(config, 'database.host') == 'localhost'
+        assert get_nested_value(config, 'database.port') == 5432
+
+    def test_get_nested_value_key_not_found(self):
+        """Test error handling when nested key doesn't exist."""
+        config = {
+            'api': {
+                'public': {
+                    'key': 'test-api-key'
+                }
+            }
+        }
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'api.public.nonexistent')
+        assert "Key path 'api.public.nonexistent' not found" in str(exc_info.value)
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'nonexistent.key')
+        assert "Key path 'nonexistent.key' not found" in str(exc_info.value)
+
+    def test_get_nested_value_partial_path(self):
+        """Test error handling when partial path exists but final key doesn't."""
+        config = {
+            'api': {
+                'public': {
+                    'key': 'test-api-key'
+                }
+            }
+        }
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'api.public.key.nonexistent')
+        assert "Key path 'api.public.key.nonexistent' not found" in str(exc_info.value)
+
+    def test_get_nested_value_safe_success(self):
+        """Test successful retrieval using safe method."""
+        config = {
+            'api': {
+                'public': {
+                    'key': 'test-api-key'
+                }
+            }
+        }
+
+        assert get_nested_value_safe(config, 'api.public.key') == 'test-api-key'
+
+    def test_get_nested_value_safe_key_not_found(self):
+        """Test error handling in safe method when key doesn't exist."""
+        config = {
+            'api': {
+                'public': {
+                    'key': 'test-api-key'
+                }
+            }
+        }
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value_safe(config, 'api.public.nonexistent')
+        assert "Configuration key 'api.public.nonexistent' not found" in str(exc_info.value)
+        assert "Please check your configuration file" in str(exc_info.value)
+
+    def test_get_nested_value_with_empty_config(self):
+        """Test behavior with empty configuration."""
+        config = {}
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'any.key')
+        assert "Key path 'any.key' not found" in str(exc_info.value)
+
+    def test_get_nested_value_with_none_config(self):
+        """Test behavior with None configuration."""
+        config = None
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'any.key')
+        assert "Key path 'any.key' not found" in str(exc_info.value)
+
+    def test_get_nested_value_with_non_dict_intermediate(self):
+        """Test behavior when intermediate value is not a dictionary."""
+        config = {
+            'api': {
+                'public': 'not-a-dict'
+            }
+        }
+
+        with pytest.raises(KeyError) as exc_info:
+            get_nested_value(config, 'api.public.key')
+        assert "Key path 'api.public.key' not found" in str(exc_info.value)

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,0 +1,351 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from automate_ui.apps.api_app.client import APIClient
+from automate_ui.common.utils.config_manager import ConfigManager
+from automate_ui.common.utils.config_manager import create_config_manager
+
+
+class TestConfigManager:
+    """Test cases for the ConfigManager class."""
+
+    def test_config_manager_initialization(self):
+        """Test ConfigManager initialization."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development',
+            aws_secret_name=None,
+            aws_region=None
+        )
+
+        assert config_manager.yaml_file_path == 'local_secrets.yaml'
+        assert config_manager.environment == 'development'
+        assert config_manager.aws_secret_name is None
+        assert config_manager.aws_region is None
+        assert config_manager.secrets is not None
+        assert config_manager.env_urls is not None
+
+    def test_get_secret(self):
+        """Test getting secrets from the config manager."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        # Test getting API key
+        api_key = config_manager.get_secret('api.public.key')
+        assert api_key == 'your-api-key-here'
+
+        # Test getting admin key
+        admin_key = config_manager.get_secret('api.private.admin_key')
+        assert admin_key == 'your-admin-key'
+
+    def test_get_url(self):
+        """Test getting environment-specific URLs."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        # Test getting API URL
+        api_url = config_manager.get_url('api.public', 'base_url')
+        assert api_url == 'https://dev-api.example.com'
+
+        # Test getting web app URL
+        web_url = config_manager.get_url('web_app', 'base_url')
+        assert web_url == 'https://www.google.com'
+
+        # Test getting admin URL
+        admin_url = config_manager.get_url('web_app', 'admin_url')
+        assert admin_url == 'https://dev-admin.example.com'
+
+    def test_get_database_config(self):
+        """Test getting database configuration."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        db_config = config_manager.get_database_config()
+
+        assert db_config['host'] == 'dev-db.example.com'
+        assert db_config['port'] == 5432
+        assert db_config['username'] == 'dev_user'
+        assert db_config['name'] == 'dev_database'
+
+    def test_get_api_config(self):
+        """Test getting complete API configuration."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        api_config = config_manager.get_api_config()
+
+        # Test public API config
+        assert api_config['public']['key'] == 'your-api-key-here'
+        assert api_config['public']['base_url'] == 'https://dev-api.example.com'
+
+        # Test private API config
+        assert api_config['private']['admin_key'] == 'your-admin-key'
+        assert api_config['private']['internal_url'] == 'https://dev-internal-api.example.com'
+
+    def test_get_web_app_config(self):
+        """Test getting web app configuration."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        web_config = config_manager.get_web_app_config()
+
+        assert web_config['base_url'] == 'https://www.google.com'
+        assert web_config['admin_url'] == 'https://dev-admin.example.com'
+
+    def test_get_aws_config(self):
+        """Test getting AWS configuration."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        aws_config = config_manager.get_aws_config()
+
+        assert aws_config['region'] == 'us-east-1'
+        assert aws_config['access_key'] == 'your-local-access-key'
+        assert aws_config['secret_key'] == 'your-local-secret-key'
+
+    def test_get_all_secrets(self):
+        """Test getting all secrets."""
+        config_manager = ConfigManager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development'
+        )
+
+        all_secrets = config_manager.get_all_secrets()
+
+        # Verify the structure
+        assert 'api' in all_secrets
+        assert 'database' in all_secrets
+        assert 'aws' in all_secrets
+
+        # Verify nested structure
+        assert 'public' in all_secrets['api']
+        assert 'private' in all_secrets['api']
+        assert 'host' in all_secrets['database']
+        assert 'port' in all_secrets['database']
+
+    def test_different_environments(self):
+        """Test that different environments return different URLs."""
+        dev_config = ConfigManager('local_secrets.yaml', 'development')
+        staging_config = ConfigManager('local_secrets.yaml', 'staging')
+        prod_config = ConfigManager('local_secrets.yaml', 'production')
+
+        # Test API URLs for different environments
+        dev_api_url = dev_config.get_url('api.public', 'base_url')
+        staging_api_url = staging_config.get_url('api.public', 'base_url')
+        prod_api_url = prod_config.get_url('api.public', 'base_url')
+
+        assert dev_api_url == 'https://dev-api.example.com'
+        assert staging_api_url == 'https://staging-api.example.com'
+        assert prod_api_url == 'https://api.example.com'
+
+        # Test web app URLs for different environments
+        dev_web_url = dev_config.get_url('web_app', 'base_url')
+        staging_web_url = staging_config.get_url('web_app', 'base_url')
+        prod_web_url = prod_config.get_url('web_app', 'base_url')
+
+        assert dev_web_url == 'https://www.google.com'
+        assert staging_web_url == 'https://staging-app.example.com'
+        assert prod_web_url == 'https://app.example.com'
+
+    def test_invalid_environment(self):
+        """Test that invalid environment raises appropriate error."""
+        with pytest.raises(KeyError) as exc_info:
+            ConfigManager('local_secrets.yaml', 'invalid_env')
+
+        assert "Environment 'invalid_env' not found" in str(exc_info.value)
+
+    def test_invalid_service(self):
+        """Test that invalid service raises appropriate error."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+        with pytest.raises(KeyError) as exc_info:
+            config_manager.get_url('invalid_service', 'base_url')
+
+        assert "Service 'invalid_service' not found" in str(exc_info.value)
+
+    def test_invalid_url_type(self):
+        """Test that invalid URL type raises appropriate error."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+        with pytest.raises(KeyError) as exc_info:
+            config_manager.get_url('web_app', 'invalid_url_type')
+
+        assert "URL type 'invalid_url_type' not found" in str(exc_info.value)
+
+    def test_invalid_secret_key(self):
+        """Test that invalid secret key raises appropriate error."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+        with pytest.raises(KeyError) as exc_info:
+            config_manager.get_secret('invalid.key')
+
+        assert "Key path 'invalid.key' not found" in str(exc_info.value)
+
+    @pytest.mark.parametrize("secret_path,expected_type", [
+        ("api.public.key", str),
+        ("database.port", int),
+        ("aws.region", str),
+    ])
+    def test_config_value_types(self, secret_path, expected_type):
+        """Test that config values have the expected types."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+        value = config_manager.get_secret(secret_path)
+        assert isinstance(value, expected_type)
+
+
+class TestCreateConfigManager:
+    """Test cases for the create_config_manager function."""
+
+    def test_create_config_manager(self):
+        """Test creating a config manager using the factory function."""
+        config_manager = create_config_manager(
+            yaml_file_path='local_secrets.yaml',
+            environment='development',
+            aws_secret_name=None,
+            aws_region=None
+        )
+
+        assert isinstance(config_manager, ConfigManager)
+        assert config_manager.yaml_file_path == 'local_secrets.yaml'
+        assert config_manager.environment == 'development'
+
+
+class TestConfigManagerIntegration:
+    """Test cases for ConfigManager integration with API client."""
+
+    def test_api_client_integration(self):
+        """Test creating API client with ConfigManager."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+        # Get API configuration
+        api_key = config_manager.get_secret('api.public.key')
+        api_url = config_manager.get_url('api.public', 'base_url')
+
+        # Create API client
+        client = APIClient(base_url=api_url)
+        client.authenticate(api_key=api_key)
+
+        # Verify client configuration
+        assert client.base_url.endswith('/api/public/')
+        assert 'Authorization' in client.session.headers
+        assert client.session.headers['Authorization'] == f'Api-Key {api_key}'
+        assert 'secret-header' in client.session.headers
+
+    def test_comprehensive_config_access(self):
+        """Test comprehensive access to all configuration types."""
+        config_manager = ConfigManager('local_secrets.yaml', 'development')
+
+        # Test all URL types
+        urls_to_test = [
+            ('api.public', 'base_url'),
+            ('api.private', 'internal_url'),
+            ('web_app', 'base_url'),
+            ('web_app', 'admin_url')
+        ]
+
+        for service, url_type in urls_to_test:
+            url = config_manager.get_url(service, url_type)
+            assert url is not None
+            assert url.startswith('https://')
+
+        # Test all secret types
+        secrets_to_test = [
+            'api.public.key',
+            'api.private.admin_key',
+            'database.host',
+            'database.port',
+            'aws.region',
+            'aws.access_key'
+        ]
+
+        for secret_path in secrets_to_test:
+            secret = config_manager.get_secret(secret_path)
+            assert secret is not None
+
+        # Test complete configurations
+        api_config = config_manager.get_api_config()
+        web_config = config_manager.get_web_app_config()
+        db_config = config_manager.get_database_config()
+        aws_config = config_manager.get_aws_config()
+
+        assert api_config is not None
+        assert web_config is not None
+        assert db_config is not None
+        assert aws_config is not None
+
+
+class TestConfigManagerWithFixture:
+    """Test cases for ConfigManager using the pytest fixture."""
+
+    def test_config_manager_fixture(self, config_manager):
+        """Test the config_manager fixture."""
+        # Test basic functionality
+        api_key = config_manager.get_secret('api.public.key')
+        api_url = config_manager.get_url('api.public', 'base_url')
+
+        assert api_key is not None
+        assert api_url is not None
+
+    def test_config_manager_with_aws_fallback(self, config_manager):
+        """Test that config_manager works with AWS fallback logic."""
+        # Get a value that should exist in our YAML file
+        api_key = config_manager.get_secret('api.public.key')
+        assert api_key is not None
+        assert isinstance(api_key, str)
+
+    def test_config_manager_missing_key_raises_error(self, config_manager):
+        """Test that accessing missing config keys raises appropriate error."""
+        with pytest.raises(KeyError) as exc_info:
+            config_manager.get_secret('nonexistent.key')
+
+        assert "Key path 'nonexistent.key' not found" in str(exc_info.value)
+
+    def test_config_manager_api_integration(self, config_manager):
+        """Test a realistic API integration scenario."""
+        # Simulate a real API integration test
+        api_key = config_manager.get_secret('api.public.key')
+        base_url = config_manager.get_url('api.public', 'base_url')
+
+        # Create client (in real scenario, you might make actual API calls)
+        client = APIClient(base_url=base_url)
+        client.authenticate(api_key=api_key)
+
+        # Verify client is properly configured for API calls
+        assert client.base_url is not None
+        assert client.session.headers['Authorization'] == f'Api-Key {api_key}'
+
+
+class TestConfigManagerCommandLineOptions:
+    """Test the config_manager fixture with different command-line options."""
+
+    def test_config_with_custom_yaml_path(self, config_manager):
+        """Test config_manager fixture with custom YAML path (would be set via --yaml-config)."""
+        # This test would be run with: pytest --yaml-config=custom_secrets.yaml
+        api_key = config_manager.get_secret('api.public.key')
+        assert api_key is not None
+
+    def test_config_with_aws_secret(self, config_manager):
+        """Test config_manager fixture with AWS secret (would be set via --aws-secret)."""
+        # This test would be run with: pytest --aws-secret=my-app-secrets
+        api_key = config_manager.get_secret('api.public.key')
+        assert api_key is not None
+
+    def test_config_with_aws_region(self, config_manager):
+        """Test config_manager fixture with AWS region (would be set via --aws-region)."""
+        # This test would be run with: pytest --aws-region=us-west-2
+        api_key = config_manager.get_secret('api.public.key')
+        assert api_key is not None


### PR DESCRIPTION
Add Config Manager. 

Config Manager can 
1. fetch secrets from yaml or aws. 
2. fetch web-app or api URIs or database configurations, for provided environments. 

Added tests for above features. 